### PR TITLE
Fixed error compiling on GCC

### DIFF
--- a/libNeonDomain/include/Neon/domain/internal/sGrid/sGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/sGrid/sGrid_imp.h
@@ -123,7 +123,7 @@ sGrid<OuterGridT>::sGrid(const OuterGridT&                  outerGrid,
         using OGCellOGCell = typename OGCell::OuterCell;
         OGCellOGCell oc;
 
-        Neon::MemoryOptions memoryOptions();
+        Neon::MemoryOptions memoryOptions;
         this->mStorage->tableToOuterCell = this->getDevSet().template newMemSet<OGCellOGCell>(Neon::DataUse::IO_COMPUTE,
                                                                                               1,
                                                                                               Neon::MemoryOptions(),


### PR DESCRIPTION
Fixed 

```
Neon/domain/internal/sGrid/sGrid_imp.h:126:42: error: empty parentheses were disambiguated as a function declaration [-Werror=vexing-parse]
  126 |         Neon::MemoryOptions memoryOptions();
```

When compiling on GCC