### PR TITLE
Optimize `mGird` for small block size 

### DIFF
--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bCell.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bCell.h
@@ -23,7 +23,8 @@ class bCell
     using BlockSizeT = int8_t;
     using OuterCell = bCell;
 
-    static constexpr BlockSizeT sBlockSize = 8;
+    //how many voxels a tray of blocks should contain in every direction
+    static constexpr BlockSizeT sBlockAllocGranularity = 8;
     static constexpr bool       sUseSwirlIndex = false;
 
     //We use uint32_t data type to store the block mask and thus the mask size is 32
@@ -57,7 +58,7 @@ class bCell
 
     NEON_CUDA_HOST_DEVICE inline auto getMaskBitPosition() const -> int32_t;
 
-    NEON_CUDA_HOST_DEVICE inline auto getBlockMaskStride() const -> int32_t;    
+    NEON_CUDA_HOST_DEVICE inline auto getBlockMaskStride() const -> int32_t;
 
     NEON_CUDA_HOST_DEVICE inline auto computeIsActive(const uint32_t* activeMask) const -> bool;
 

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bCell_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bCell_imp.h
@@ -361,7 +361,8 @@ NEON_CUDA_HOST_DEVICE inline auto bCell::getMaskBitPosition() const -> int32_t
 
 NEON_CUDA_HOST_DEVICE inline auto bCell::getBlockMaskStride() const -> int32_t
 {
-    return mBlockID * NEON_DIVIDE_UP(mBlockSize * mBlockSize * mBlockSize, sMaskSize);
+    //return NEON_DIVIDE_UP(mBlockID * mBlockSize * mBlockSize * mBlockSize, sMaskSize);
+    return mBlockID* NEON_DIVIDE_UP(mBlockSize * mBlockSize * mBlockSize, sMaskSize);
 }
 
 

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bField_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bField_imp.h
@@ -26,14 +26,12 @@ bField<T, C>::bField(const std::string&             name,
     mData->grid = std::make_shared<bGrid>(grid);
     mData->mCardinality = cardinality;
 
-    int blockSize = mData->grid->getBlockSize();
-
     //the allocation size is the number of blocks x block size x cardinality
     Neon::set::DataSet<uint64_t> allocSize;
     allocSize = mData->grid->getBackend().devSet().template newDataSet<uint64_t>();
     for (int64_t i = 0; i < allocSize.size(); ++i) {
-        allocSize[i] = mData->grid->getNumBlocks()[i] *
-                       blockSize * blockSize * blockSize *
+        allocSize[i] = mData->grid->getNumTrays()[i] *
+                       Cell::sBlockAllocGranularity * Cell::sBlockAllocGranularity * Cell::sBlockAllocGranularity *
                        cardinality;
     }
 

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid.h
@@ -119,6 +119,7 @@ class bGrid : public Neon::domain::interface::GridBaseTemplate<bGrid, bCell>
     auto getDimension() const -> const Neon::index_3d;
 
     auto getNumBlocks() const -> const Neon::set::DataSet<uint64_t>&;
+    auto getNumTrays() const -> const Neon::set::DataSet<uint64_t>&;
     auto getBlockSize() const -> int;
     auto getVoxelSpacing() const -> int;
     auto getOriginBlock3DIndex(const Neon::int32_3d idx) const -> Neon::int32_3d;

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid.h
@@ -119,6 +119,7 @@ class bGrid : public Neon::domain::interface::GridBaseTemplate<bGrid, bCell>
     auto getDimension() const -> const Neon::index_3d;
 
     auto getNumBlocks() const -> const Neon::set::DataSet<uint64_t>&;
+    auto getNumBlocksAlocSize() const -> const Neon::set::DataSet<uint64_t>&;
     auto getNumTrays() const -> const Neon::set::DataSet<uint64_t>&;
     auto getBlockSize() const -> int;
     auto getVoxelSpacing() const -> int;
@@ -164,6 +165,8 @@ class bGrid : public Neon::domain::interface::GridBaseTemplate<bGrid, bCell>
         //a tray could contains one or more blocks
         //blocks within a tray take contiguous numbers
         Neon::set::DataSet<uint64_t> mNumTrays;
+        //number of blocks for allocation purposes
+        Neon::set::DataSet<uint64_t> mNumBlockAlocSize;
     };
     std::shared_ptr<Data> mData;
 };

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid.h
@@ -131,17 +131,13 @@ class bGrid : public Neon::domain::interface::GridBaseTemplate<bGrid, bCell>
         int blockSize;
         int voxelSpacing;
 
-        //number of active voxels in each block
-        Neon::set::DataSet<uint64_t> mNumActiveVoxel;
-
         //block origin coordinates
         Neon::set::MemSet_t<Neon::int32_3d> mOrigin;
 
         //Stencil neighbor indices
         Neon::set::MemSet_t<nghIdx_t> mStencilNghIndex;
 
-
-        Neon::set::DataSet<uint64_t>  mActiveMaskSize;
+        //bitmask to indicate active voxels within a block
         Neon::set::MemSet_t<uint32_t> mActiveMask;
 
 
@@ -162,6 +158,11 @@ class bGrid : public Neon::domain::interface::GridBaseTemplate<bGrid, bCell>
 
         //number of blocks in each device
         Neon::set::DataSet<uint64_t> mNumBlocks;
+
+        //number of trays in each device
+        //a tray could contains one or more blocks
+        //blocks within a tray take contiguous numbers
+        Neon::set::DataSet<uint64_t> mNumTrays;
     };
     std::shared_ptr<Data> mData;
 };

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -31,6 +31,13 @@ bGrid::bGrid(const Neon::Backend&         backend,
         NEON_THROW(exp);
     }
 
+    if (blockSize > Cell::sBlockAllocGranularity) {
+        NeonException exp("bGrid");
+        exp << "Input block size (" << blockSize << ") is larger than block allocation granularity (" << Cell::sBlockAllocGranularity << ")";
+        exp << "We only support block sizes smaller than or equal to the block allocation granularity";
+        NEON_THROW(exp);
+    }
+
     mData = std::make_shared<Data>();
     mData->blockSize = blockSize;
     mData->voxelSpacing = voxelSpacing;

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -38,6 +38,14 @@ bGrid::bGrid(const Neon::Backend&         backend,
         NEON_THROW(exp);
     }
 
+
+    if (blockSize > Cell::sBlockAllocGranularity) {
+        NeonException exp("bGrid");
+        exp << "Input block size (" << blockSize << ") is larger than block allocation granularity (" << Cell::sBlockAllocGranularity << ")";
+        exp << "We only support block sizes smaller than or equal to the block allocation granularity";
+        NEON_THROW(exp);
+    }
+
     mData = std::make_shared<Data>();
     mData->blockSize = blockSize;
     mData->voxelSpacing = voxelSpacing;

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -9,7 +9,7 @@ bGrid::bGrid(const Neon::Backend&         backend,
              const Neon::domain::Stencil& stencil,
              const double_3d&             spacingData,
              const double_3d&             origin)
-    : bGrid(backend, domainSize, activeCellLambda, stencil, 2, 1, spacingData, origin)
+    : bGrid(backend, domainSize, activeCellLambda, stencil, 8, 1, spacingData, origin)
 {
 }
 
@@ -56,12 +56,12 @@ bGrid::bGrid(const Neon::Backend&         backend,
                                    NEON_DIVIDE_UP(domainSize.z, bCell::sBlockAllocGranularity));
 
     //how many blocks a tray contains
-    const int blocksPerTray = NEON_DIVIDE_UP(blockSize, bCell::sBlockAllocGranularity);
+    const int blocksPerTray = NEON_DIVIDE_UP(bCell::sBlockAllocGranularity, blockSize);
 
     //we loop over trays to make sure that blocks within a tray takes contiguous numbers
-    for (int gz = 0; gz < numTrayInDomain.x; gz++) {
+    for (int gz = 0; gz < numTrayInDomain.z; gz++) {
         for (int gy = 0; gy < numTrayInDomain.y; gy++) {
-            for (int gx = 0; gx < numTrayInDomain.z; gx++) {
+            for (int gx = 0; gx < numTrayInDomain.x; gx++) {
 
                 Neon::int32_3d trayOrigin(gx * bCell::sBlockAllocGranularity * voxelSpacing,
                                           gy * bCell::sBlockAllocGranularity * voxelSpacing,

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -82,7 +82,8 @@ bGrid::bGrid(const Neon::Backend&         backend,
                                           gy * bCell::sBlockAllocGranularity * voxelSpacing,
                                           gz * bCell::sBlockAllocGranularity * voxelSpacing);
 
-                int numBlocksInTray = 0;
+                int      numBlocksInTray = 0;
+                uint32_t blockId = uint32_t( mData->mNumTrays[0] * blocksPerTray * blocksPerTray * blocksPerTray);
 
                 for (int bz = 0; bz < blocksPerTray; bz++) {
                     for (int by = 0; by < blocksPerTray; by++) {
@@ -112,11 +113,12 @@ bGrid::bGrid(const Neon::Backend&         backend,
                             numActiveVoxel[0] += numVoxelsInBlock;
 
                             if (numVoxelsInBlock > 0) {
-                                mData->mNumBlocks[0]++;
-                                mData->mBlockOriginTo1D.addPoint(blockOrigin,
-                                                                 uint32_t(numBlocksInTray + mData->mNumTrays[0] * blocksPerTray * blocksPerTray * blocksPerTray));
+                                mData->mNumBlocks[0]++;                                
+                                mData->mBlockOriginTo1D.addPoint(blockOrigin, blockId);
                                 numBlocksInTray++;
                             }
+
+                            blockId++;
                         }
                     }
                 }

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -99,7 +99,7 @@ bGrid::bGrid(const Neon::Backend&         backend,
                             if (numVoxelsInBlock > 0) {
                                 mData->mNumBlocks[0]++;
                                 mData->mBlockOriginTo1D.addPoint(blockOrigin,
-                                                                 uint32_t(numBlocksInTray + mData->mNumTrays[0] * blocksPerTray));
+                                                                 uint32_t(numBlocksInTray + mData->mNumTrays[0] * blocksPerTray * blocksPerTray * blocksPerTray));
                                 numBlocksInTray++;
                             }
                         }
@@ -152,7 +152,7 @@ bGrid::bGrid(const Neon::Backend&         backend,
     //we do this since the allocation granularity is the tray size (not the block size)
     Neon::set::DataSet<uint64_t> numBlockAlocSize = backend.devSet().template newDataSet<uint64_t>();
     for (int64_t i = 0; i < numBlockAlocSize.size(); ++i) {
-        numBlockAlocSize[i] = mData->mNumTrays[i] * blocksPerTray;
+        numBlockAlocSize[i] = mData->mNumTrays[i] * blocksPerTray * blocksPerTray * blocksPerTray;
     }
 
     //origin

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -182,7 +182,6 @@ bGrid::bGrid(const Neon::Backend&         backend,
 
 
     // block bitmask
-    const auto                   g = bCell::sBlockAllocGranularity;
     Neon::set::DataSet<uint64_t> activeMaskSize = backend.devSet().template newDataSet<uint64_t>();
     for (int64_t i = 0; i < activeMaskSize.size(); ++i) {
         activeMaskSize[i] = numBlockAlocSize[i] *

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bGrid_imp.h
@@ -180,11 +180,14 @@ bGrid::bGrid(const Neon::Backend&         backend,
 
 
     // block bitmask
+    const auto                   g = bCell::sBlockAllocGranularity;
     Neon::set::DataSet<uint64_t> activeMaskSize = backend.devSet().template newDataSet<uint64_t>();
     for (int64_t i = 0; i < activeMaskSize.size(); ++i) {
         activeMaskSize[i] = numBlockAlocSize[i] *
                             NEON_DIVIDE_UP(blockSize * blockSize * blockSize,
                                            Cell::sMaskSize);
+        //activeMaskSize[i] = NEON_DIVIDE_UP(mData->mNumTrays[i] * g * g * g,
+        //                                   Cell::sMaskSize);
     }
 
     mData->mActiveMask = backend.devSet().template newMemSet<uint32_t>({Neon::DataUse::IO_COMPUTE},
@@ -306,7 +309,6 @@ bGrid::bGrid(const Neon::Backend&         backend,
             mData->mPartitionIndexSpace[dv_id][gpuIdx].mDomainSize = domainSize * voxelSpacing;
             mData->mPartitionIndexSpace[dv_id][gpuIdx].mBlockSize = blockSize;
             mData->mPartitionIndexSpace[dv_id][gpuIdx].mSpacing = voxelSpacing;
-            mData->mPartitionIndexSpace[dv_id][gpuIdx].mNumBlocks = static_cast<uint32_t>(mData->mNumBlocks[gpuIdx]);
             mData->mPartitionIndexSpace[dv_id][gpuIdx].mHostActiveMask = mData->mActiveMask.rawMem(gpuIdx, Neon::DeviceType::CPU);
             mData->mPartitionIndexSpace[dv_id][gpuIdx].mDeviceActiveMask = mData->mActiveMask.rawMem(gpuIdx, Neon::DeviceType::CUDA);
             mData->mPartitionIndexSpace[dv_id][gpuIdx].mHostBlockOrigin = mData->mOrigin.rawMem(gpuIdx, Neon::DeviceType::CPU);

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition.h
@@ -65,6 +65,7 @@ class bPartition
     inline NEON_CUDA_HOST_DEVICE auto getNghCell(const Cell& cell, const nghIdx_t& offset) const -> Cell;
 
    protected:
+    virtual inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int;
     inline NEON_CUDA_HOST_DEVICE auto pitch(const Cell& cell, int card) const -> uint32_t;
     inline NEON_CUDA_HOST_DEVICE auto getNghCell(const Cell& cell, const nghIdx_t& offset, const uint32_t* neighbourBlocks) const -> Cell;
     inline NEON_CUDA_HOST_DEVICE auto shmemPitch(Cell cell, const int card) const -> Cell::Location::Integer;

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition.h
@@ -49,7 +49,7 @@ class bPartition
     NEON_CUDA_HOST_DEVICE inline auto nghVal(const Cell& eId,
                                              uint8_t     nghID,
                                              int         card,
-                                             const T&    alternativeVal) const -> NghInfo<T>;    
+                                             const T&    alternativeVal) const -> NghInfo<T>;
 
 
     NEON_CUDA_HOST_DEVICE inline void loadInSharedMemory(const Cell&                cell,
@@ -67,7 +67,7 @@ class bPartition
    protected:
     inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int;
     inline NEON_CUDA_HOST_DEVICE auto pitch(const Cell& cell, int card) const -> uint32_t;
-    inline NEON_CUDA_HOST_DEVICE auto getNghCell(const Cell& cell, const nghIdx_t& offset, const uint32_t* neighbourBlocks) const -> Cell;
+    inline NEON_CUDA_HOST_DEVICE auto getNghCell(const Cell& cell, const nghIdx_t& offset, const uint32_t* neighbourBlocks, const int spacing = 1) const -> Cell;
     inline NEON_CUDA_HOST_DEVICE auto shmemPitch(Cell cell, const int card) const -> Cell::Location::Integer;
     inline NEON_CUDA_HOST_DEVICE auto getneighbourBlocksPtr(const Cell& cell) const -> const uint32_t*;
 

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition.h
@@ -65,7 +65,7 @@ class bPartition
     inline NEON_CUDA_HOST_DEVICE auto getNghCell(const Cell& cell, const nghIdx_t& offset) const -> Cell;
 
    protected:
-    virtual inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int;
+    inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int;
     inline NEON_CUDA_HOST_DEVICE auto pitch(const Cell& cell, int card) const -> uint32_t;
     inline NEON_CUDA_HOST_DEVICE auto getNghCell(const Cell& cell, const nghIdx_t& offset, const uint32_t* neighbourBlocks) const -> Cell;
     inline NEON_CUDA_HOST_DEVICE auto shmemPitch(Cell cell, const int card) const -> Cell::Location::Integer;

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartitionIndexSpace.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartitionIndexSpace.h
@@ -30,7 +30,6 @@ class bPartitionIndexSpace
     Neon::int32_3d  mDomainSize;
     int             mBlockSize;
     int             mSpacing;
-    uint32_t        mNumBlocks;
     uint32_t*       mHostActiveMask;
     uint32_t*       mDeviceActiveMask;
     Neon::int32_3d* mHostBlockOrigin;

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartitionIndexSpace_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartitionIndexSpace_imp.h
@@ -59,10 +59,6 @@ bPartitionIndexSpace::setAndValidate(bCell&        cell,
     Neon::int32_3d* blockOrigin = mHostBlockOrigin;
 #endif
 
-    if (cell.mBlockID >= mNumBlocks) {
-        cell.mIsActive = false;
-    }
-
 
     if (blockOrigin[cell.mBlockID].x + cell.mLocation.x * mSpacing >= mDomainSize.x ||
         blockOrigin[cell.mBlockID].y + cell.mLocation.y * mSpacing >= mDomainSize.y ||

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition_imp.h
@@ -68,6 +68,12 @@ NEON_CUDA_HOST_DEVICE inline auto bPartition<T, C>::mapToGlobal(const Cell& cell
 }
 
 template <typename T, int C>
+inline NEON_CUDA_HOST_DEVICE auto bPartition<T, C>::getSpacing() const -> int
+{
+    return 1;
+}
+
+template <typename T, int C>
 inline NEON_CUDA_HOST_DEVICE auto bPartition<T, C>::cardinality() const -> int
 {
     return mCardinality;
@@ -186,22 +192,25 @@ NEON_CUDA_HOST_DEVICE inline auto bPartition<T, C>::getNghCell(const Cell&     c
 
     //if the block size is less the block allocation granularity, then this means we can implicitly get the neighbor cell implicitly
     if (nghCell.mBlockSize < Cell::sBlockAllocGranularity) {
-        const Neon::int32_3d cellOrigin = mOrigin[cell.mBlockID] + cell.mLocation.newType<int32_t>();
-        const Neon::int32_3d cellTray(cellOrigin.x / Cell::sBlockAllocGranularity,
-                                      cellOrigin.y / Cell::sBlockAllocGranularity,
-                                      cellOrigin.z / Cell::sBlockAllocGranularity);
+        
+        const int spacing = getSpacing();
 
+        const Neon::int32_3d cellOrigin = mOrigin[cell.mBlockID] / spacing + cell.mLocation.newType<int32_t>();
+                
         Neon::int32_3d nghOrigin(cellOrigin.x + offset.x, cellOrigin.y + offset.y, cellOrigin.z + offset.z);
         if (nghOrigin.x < 0 || nghOrigin.y < 0 || nghOrigin.z < 0) {
             nghCell.mBlockID = std::numeric_limits<uint32_t>::max();
 
         } else {
-            Neon::int32_3d nghTray(nghOrigin.x / Cell::sBlockAllocGranularity,
-                                   nghOrigin.y / Cell::sBlockAllocGranularity,
-                                   nghOrigin.z / Cell::sBlockAllocGranularity);
+            const Neon::int32_3d nghTray(nghOrigin.x / Cell::sBlockAllocGranularity,
+                                         nghOrigin.y / Cell::sBlockAllocGranularity,
+                                         nghOrigin.z / Cell::sBlockAllocGranularity);
 
             //if the neighbor does not live in the same tray, then we do the usual nghCell
             //where we try to find the neighbor using neighbor block ID
+            const Neon::int32_3d cellTray(cellOrigin.x / Cell::sBlockAllocGranularity,
+                                          cellOrigin.y / Cell::sBlockAllocGranularity,
+                                          cellOrigin.z / Cell::sBlockAllocGranularity);
             if (cellTray != nghTray) {
                 nghCell.mBlockID = neighbourBlocks[calcOffsetBlock()];
 

--- a/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/bGrid/bPartition_imp.h
@@ -208,9 +208,11 @@ NEON_CUDA_HOST_DEVICE inline auto bPartition<T, C>::getNghCell(const Cell&     c
             } else {
                 //otherwise, nghCell may resides on a different block in the same tray
                 if (isNghInDifferentBlock()) {
-                    nghCell.mBlockID = cell.mBlockID + offset.mPitch(Neon::index_3d(Cell::sBlockAllocGranularity,
-                                                                                    Cell::sBlockAllocGranularity,
-                                                                                    Cell::sBlockAllocGranularity));
+                    const int numBlockPerTray = Cell::sBlockAllocGranularity / cell.mBlockSize;
+
+                    nghCell.mBlockID = cell.mBlockID + offset.mPitch(Neon::index_3d(numBlockPerTray,
+                                                                                    numBlockPerTray,
+                                                                                    numBlockPerTray));
                 } else {
                     //or nghCell may reside on the same block
                     nghCell.mBlockID = cell.mBlockID;

--- a/libNeonDomain/include/Neon/domain/internal/mGrid/mGrid.h
+++ b/libNeonDomain/include/Neon/domain/internal/mGrid/mGrid.h
@@ -139,7 +139,6 @@ class mGrid
                              int                   level) const -> Neon::set::LaunchParameters;
 
 
-    auto getNumBlocksPerPartition(int level) const -> const Neon::set::DataSet<uint64_t>&;
     auto getParentsBlockID(int level) const -> const Neon::set::MemSet_t<uint32_t>&;
     auto getParentLocalID(int level) const -> const Neon::set::MemSet_t<Cell::Location>&;
     auto getChildBlockID(int level) const -> const Neon::set::MemSet_t<uint32_t>&;
@@ -210,8 +209,6 @@ class mGrid
 
         bool mStrongBalanced;
 
-        //bitmask of the active cells at each level and works as if the grid is dense at each level
-        std::vector<std::vector<uint32_t>> denseLevelsBitmask;
 
         //collection of bGrids that make up the multi-resolution grid
         std::vector<InternalGrid> grids;

--- a/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition.h
+++ b/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition.h
@@ -160,6 +160,16 @@ class mPartition : public Neon::domain::internal::bGrid::bPartition<T, C>
     */
     NEON_CUDA_HOST_DEVICE inline Neon::index_3d mapToGlobal(const Cell& cell) const;
 
+    NEON_CUDA_HOST_DEVICE inline auto nghVal(const Cell&     cell,
+                                             const nghIdx_t& offset,
+                                             const int       card,
+                                             const T         alternativeVal) const -> NghInfo<T>;
+
+    NEON_CUDA_HOST_DEVICE inline auto nghVal(const Cell& eId,
+                                             uint8_t     nghID,
+                                             int         card,
+                                             const T&    alternativeVal) const -> NghInfo<T>;
+
 
    private:
     inline NEON_CUDA_HOST_DEVICE auto childID(const Cell& cell) const -> uint32_t;

--- a/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition.h
+++ b/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition.h
@@ -163,7 +163,7 @@ class mPartition : public Neon::domain::internal::bGrid::bPartition<T, C>
 
    private:
     inline NEON_CUDA_HOST_DEVICE auto childID(const Cell& cell) const -> uint32_t;
-    inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int override;
+    inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int;
 
 
     int             mLevel;

--- a/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition.h
+++ b/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition.h
@@ -163,6 +163,7 @@ class mPartition : public Neon::domain::internal::bGrid::bPartition<T, C>
 
    private:
     inline NEON_CUDA_HOST_DEVICE auto childID(const Cell& cell) const -> uint32_t;
+    inline NEON_CUDA_HOST_DEVICE auto getSpacing() const -> int override;
 
 
     int             mLevel;

--- a/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition_imp.h
+++ b/libNeonDomain/include/Neon/domain/internal/mGrid/mPartition_imp.h
@@ -62,7 +62,7 @@ NEON_CUDA_HOST_DEVICE inline Neon::index_3d mPartition<T, C>::mapToGlobal(const 
         ret.z += swirl.mLocation.z;
     } else {
 #endif
-        const int sp = (mLevel == 0) ? 1 : mSpacing[mLevel - 1];
+        const int sp = getSpacing();
         ret.x += cell.mLocation.x * sp;
         ret.y += cell.mLocation.y * sp;
         ret.z += cell.mLocation.z * sp;
@@ -80,9 +80,15 @@ NEON_CUDA_HOST_DEVICE inline auto mPartition<T, C>::getRefFactor(const int level
 }
 
 template <typename T, int C>
+inline NEON_CUDA_HOST_DEVICE auto mPartition<T, C>::getSpacing() const -> int
+{
+    return getSpacing(mLevel);
+}
+
+template <typename T, int C>
 NEON_CUDA_HOST_DEVICE inline auto mPartition<T, C>::getSpacing(const int level) const -> int
 {
-    return mSpacing[level];
+    return (level == 0) ? 1 : mSpacing[mLevel - 1];
 }
 
 template <typename T, int C>

--- a/libNeonDomain/src/domain/internal/bGrid/bGrid.cpp
+++ b/libNeonDomain/src/domain/internal/bGrid/bGrid.cpp
@@ -149,6 +149,10 @@ auto bGrid::getNumBlocks() const -> const Neon::set::DataSet<uint64_t>&
     return mData->mNumBlocks;
 }
 
+auto bGrid::getNumBlocksAlocSize() const -> const Neon::set::DataSet<uint64_t>&
+{
+    return mData->mNumBlockAlocSize;
+}
 auto bGrid::getNumTrays() const -> const Neon::set::DataSet<uint64_t>&
 {
     return mData->mNumTrays;

--- a/libNeonDomain/src/domain/internal/bGrid/bGrid.cpp
+++ b/libNeonDomain/src/domain/internal/bGrid/bGrid.cpp
@@ -149,6 +149,11 @@ auto bGrid::getNumBlocks() const -> const Neon::set::DataSet<uint64_t>&
     return mData->mNumBlocks;
 }
 
+auto bGrid::getNumTrays() const -> const Neon::set::DataSet<uint64_t>&
+{
+    return mData->mNumTrays;
+}
+
 auto bGrid::getBlockSize() const -> int
 {
     return mData->blockSize;

--- a/libNeonDomain/src/domain/internal/bGrid/bGrid.cpp
+++ b/libNeonDomain/src/domain/internal/bGrid/bGrid.cpp
@@ -81,22 +81,22 @@ auto bGrid::getLaunchParameters([[maybe_unused]] Neon::DataView        dataView,
     //                 Neon::DataViewUtil::toString(dataView));
     //}
 
-    const Neon::int32_3d cuda_block(mData->blockSize,
-                                    mData->blockSize,
-                                    mData->blockSize);
+    const Neon::int32_3d cuda_block(Cell::sBlockAllocGranularity,
+                                    Cell::sBlockAllocGranularity,
+                                    Cell::sBlockAllocGranularity);
 
     Neon::set::LaunchParameters ret = getBackend().devSet().newLaunchParameters();
     for (int i = 0; i < ret.cardinality(); ++i) {
         if (getBackend().devType() == Neon::DeviceType::CUDA) {
             ret[i].set(Neon::sys::GpuLaunchInfo::mode_e::cudaGridMode,
-                       Neon::int32_3d(int32_t(mData->mNumBlocks[i]), 1, 1),
+                       Neon::int32_3d(int32_t(mData->mNumTrays[i]), 1, 1),
                        cuda_block, sharedMem);
         } else {
             ret[i].set(Neon::sys::GpuLaunchInfo::mode_e::domainGridMode,
-                       Neon::int32_3d(int32_t(mData->mNumBlocks[i]) *
-                                          mData->blockSize *
-                                          mData->blockSize *
-                                          mData->blockSize,
+                       Neon::int32_3d(int32_t(mData->mNumTrays[i]) *
+                                          cuda_block.x *
+                                          cuda_block.y *
+                                          cuda_block.z,
                                       1, 1),
                        cuda_block, sharedMem);
         }

--- a/libNeonDomain/tests/unit/gUt_bGrid/src/gUt_bGrid.cpp
+++ b/libNeonDomain/tests/unit/gUt_bGrid/src/gUt_bGrid.cpp
@@ -8,7 +8,7 @@ TEST(bGrid, activeCell)
 {
     if (Neon::sys::globalSpace::gpuSysObjStorage.numDevs() > 0) {
         int              nGPUs = 1;
-        Neon::int32_3d   dim(16, 16, 16);
+        Neon::int32_3d   dim(10, 10, 1);
         std::vector<int> gpusIds(nGPUs, 0);
         auto             bk = Neon::Backend(gpusIds, Neon::Runtime::stream);
 
@@ -16,22 +16,25 @@ TEST(bGrid, activeCell)
             bk,
             dim,
             [&](const Neon::index_3d& id) -> bool {
-                if (id.x % 8 == 0 && id.y % 8 == 0 && id.z % 8 == 0 && id.x == id.y && id.y == id.z) {
+                if ((id.x == 0 && id.y == 0) ||
+                    (id.x == 4 && id.y == 4) ||
+                    (id.x == 9 && id.y == 0)) {
                     return true;
                 } else {
                     return false;
                 }
             },
-            Neon::domain::Stencil::s7_Laplace_t());
+            Neon::domain::Stencil::s7_Laplace_t(), 2, 1);
 
-        auto field = b_grid.newField<float>("myField", 1, 0);
+        auto field = b_grid.newField<float>("myField", 1, -5);
 
         //field.ioToVtk("f", "f");
 
         field.forEachActiveCell(
             [](const Neon::int32_3d id, const int card, float) {
-                EXPECT_TRUE(((id.x == 0 && id.y == 0 && id.z == 0) ||
-                             (id.x == 8 && id.y == 8 && id.z == 8)) &&
+                EXPECT_TRUE(((id.x == 0 && id.y == 0) ||
+                             (id.x == 4 && id.y == 4) ||
+                             (id.x == 9 && id.y == 0)) &&
                             card == 0);
             },
             Neon::computeMode_t::computeMode_e::seq);

--- a/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/src/sUt.runHelper.h
+++ b/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/src/sUt.runHelper.h
@@ -34,7 +34,7 @@ void runAllTestConfiguration(const std::string&                      gname,
 
         std::vector<int> cardinalityTest{1};
 
-        std::vector<Neon::index_3d> dimTest{{64, 16, 252}};
+        std::vector<Neon::index_3d> dimTest{{25, 33, 252}};
         std::vector<Neon::Runtime>  runtimeE{Neon::Runtime::openmp, Neon::Runtime::stream};
 
         std::vector<Geometry> geos;

--- a/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/src/sUt_skeleton.Stencil.cu
+++ b/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/src/sUt_skeleton.Stencil.cu
@@ -124,8 +124,11 @@ void SingleStencil(TestData<G, T, C>&      data,
         X.updateCompute(0);
         X.ioToVtk("X", "X");*/
 
-        ops.push_back(laplace(X, Y, Y.getSharedMemoryBytes(1)));
-        ops.push_back(axpy(val, Y, X, Y.getSharedMemoryBytes(1)));
+        //ops.push_back(laplace(X, Y, Y.getSharedMemoryBytes(1)));
+        //ops.push_back(axpy(val, Y, X, Y.getSharedMemoryBytes(1)));
+
+        ops.push_back(laplace(X, Y));
+        ops.push_back(axpy(val, Y, X));
 
         skl.sequence(ops, appName, opt);
 

--- a/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/src/sUt_skeleton.Stencil.cu
+++ b/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/src/sUt_skeleton.Stencil.cu
@@ -141,6 +141,8 @@ void SingleStencil(TestData<G, T, C>&      data,
         cudaProfilerStop();
         NEON_CUDA_CHECK_LAST_ERROR
 
+        //X.updateIO(0);
+        //Y.updateIO(0);
         //X.ioToVtk("X", "X");
         //Y.ioToVtk("Y", "Y");
     }
@@ -157,6 +159,13 @@ void SingleStencil(TestData<G, T, C>&      data,
 
     bool isOk = data.compare(FieldNames::X);
     isOk = isOk && data.compare(FieldNames::Y);
+
+    //data.getField(FieldNames::X).ioFromDense(data.mIODomains[0].getData());
+    //data.getField(FieldNames::X).ioToVtk("Xd", "Xd");
+
+    //data.getField(FieldNames::Y).ioFromDense(data.mIODomains[1].getData());
+    //data.getField(FieldNames::Y).ioToVtk("Yd", "Xd");
+
 
     ASSERT_TRUE(isOk);
 }

--- a/libNeonSkeleton/tests/unit/sUt_stencil/src/sUt_stencil.cu
+++ b/libNeonSkeleton/tests/unit/sUt_stencil/src/sUt_stencil.cu
@@ -160,7 +160,7 @@ TEST(Stencil_NoOCC, dGrid)
     runAllTestConfiguration<Grid, Type, 0>("dGrid_t", SingleStencil<Grid, Type, 0>, nGpus, 1);
 }
 
-TEST(DISABLED_Stencil_NoOCC, DISABLED_bGrid)
+TEST(Stencil_NoOCC, bGrid)
 {
     int nGpus = 1;
     using Grid = Neon::domain::bGrid;


### PR DESCRIPTION
When creating `mGrid` the branching factor could be small (2 for octree). Since CUDA blocks have the same size of the grid block, this leads to launching small block (8 thread/block) which severely hurt the performance. This PR mitigate this problem by introducing the `tray` concept. A `tray` is just logical aggergation of grid block into larger block (default to 8^3 voxels per block). If the grid block is large enough (i.e., 8^3 voxels) the block will coincide with the tray. Using, the tray, we launch enough threads per block to cover a single tray. Communication between blocks in the same tray is done implicitly. Allocation granularity is now per tray size (not block size)