### PR TITLE
Fix issue with VS2022

### DIFF
--- a/libNeonCore/tests/unit/coreUt_chrono/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_chrono/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_chrono
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_chrono PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_chrono PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_chrono" FILES ${SrcFiles})
 
 add_test(NAME coreUt_chrono COMMAND coreUt_chrono)

--- a/libNeonCore/tests/unit/coreUt_cli/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_cli/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_cli
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_cli PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_cli PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_cli" FILES ${SrcFiles})
 
 add_test(NAME coreUt_cli COMMAND coreUt_cli)

--- a/libNeonCore/tests/unit/coreUt_digraph/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_digraph/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_digraph
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_digraph PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_digraph PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_digraph" FILES ${SrcFiles})
 
 add_test(NAME coreUt_digraph COMMAND coreUt_digraph)

--- a/libNeonCore/tests/unit/coreUt_exceptions/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_exceptions/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_exceptions
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_exceptions PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_exceptions PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_exceptions" FILES ${SrcFiles})
 
 add_test(NAME coreUt_exceptions COMMAND coreUt_exceptions)

--- a/libNeonCore/tests/unit/coreUt_io/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_io/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_io
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_io PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_io PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_io" FILES ${SrcFiles})
 
 add_test(NAME coreUt_io COMMAND coreUt_io)

--- a/libNeonCore/tests/unit/coreUt_logging/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_logging/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_logging
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_logging PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_logging PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_logging" FILES ${SrcFiles})
 
 add_test(NAME coreUt_logging COMMAND coreUt_logging)

--- a/libNeonCore/tests/unit/coreUt_tools/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_tools/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_tools
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_tools PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_tools PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_tools" FILES ${SrcFiles})
 
 add_test(NAME coreUt_tools COMMAND coreUt_tools)

--- a/libNeonCore/tests/unit/coreUt_tuple3d/CMakeLists.txt
+++ b/libNeonCore/tests/unit/coreUt_tuple3d/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(coreUt_tuple3d
 	PUBLIC libNeonCore
 	PUBLIC gtest_main)
 
-set_target_properties(coreUt_tuple3d PROPERTIES FOLDER "libNeonCore")
+set_target_properties(coreUt_tuple3d PROPERTIES FOLDER "libNeonCoreTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "coreUt_tuple3d" FILES ${SrcFiles})
 
 add_test(NAME coreUt_tuple3d COMMAND coreUt_tuple3d)

--- a/libNeonDomain/tests/domain-bGrid-tray/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-bGrid-tray/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(${APP_NAME} PROPERTIES
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "${APP_NAME}" FILES ${SrcFiles})
 
 add_test(NAME ${APP_NAME} COMMAND ${APP_NAME})

--- a/libNeonDomain/tests/domain-globalIdx/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-globalIdx/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(${APP_NAME} PROPERTIES
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "${APP_NAME}" FILES ${SrcFiles})
 
 add_test(NAME ${APP_NAME} COMMAND ${APP_NAME})

--- a/libNeonDomain/tests/domain-halos/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-halos/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(${APP_NAME}
 		PUBLIC libNeonDomain
 		PUBLIC gtest_main)
 
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX ${APP_NAME} FILES ${SrcFiles})
 
 

--- a/libNeonDomain/tests/domain-host-containers/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-host-containers/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(domain-host-containers
 set_target_properties(domain-host-containers PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(domain-host-containers PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(domain-host-containers PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "domain-host-containers" FILES ${SrcFiles})
 
 add_test(NAME domain-host-containers COMMAND domain-host-containers)

--- a/libNeonDomain/tests/domain-map/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-map/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(domain-map
 set_target_properties(domain-map PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(domain-map PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(domain-map PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "domain-map" FILES ${SrcFiles})
 
 add_test(NAME domain-map COMMAND domain-map)

--- a/libNeonDomain/tests/domain-neighbour-globalIdx/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-neighbour-globalIdx/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(${APP_NAME} PROPERTIES
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "${APP_NAME}" FILES ${SrcFiles})
 
 add_test(NAME ${APP_NAME} COMMAND ${APP_NAME})

--- a/libNeonDomain/tests/domain-stencil/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-stencil/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(${APP_NAME}
 		PUBLIC libNeonDomain
 		PUBLIC gtest_main)
 
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX ${APP_NAME} FILES ${SrcFiles})
 
 

--- a/libNeonDomain/tests/domain-unit-test-cast/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-unit-test-cast/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(domain-unit-test-cast
 set_target_properties(domain-unit-test-cast PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(domain-unit-test-cast PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(domain-unit-test-cast PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE . PREFIX "domain-unit-test-cast" FILES ${SrcFiles})
 
 add_test(NAME domain-unit-test-cast COMMAND domain-unit-test-cast)

--- a/libNeonDomain/tests/domain-unit-test-eGrid/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-unit-test-eGrid/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(${APP_NAME}
 set_target_properties(${APP_NAME} PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "${APP_NAME}" FILES ${SrcFiles})
 
 add_test(NAME ${APP_NAME} COMMAND ${APP_NAME})

--- a/libNeonDomain/tests/domain-unit-test-gridInterface/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-unit-test-gridInterface/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(${APP_NAME}
 set_target_properties(${APP_NAME} PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "${APP_NAME}" FILES ${SrcFiles})
 
 add_test(NAME ${APP_NAME} COMMAND ${APP_NAME})

--- a/libNeonDomain/tests/domain-unit-test-patterns-containers/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-unit-test-patterns-containers/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(${APP_NAME}
 	PUBLIC libNeonDomain
 	PUBLIC gtest_main)
 
-set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(${APP_NAME} PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX ${APP_NAME} FILES ${SrcFiles})
 
 add_test(NAME ${APP_NAME} COMMAND ${APP_NAME})

--- a/libNeonDomain/tests/domain-unit-test-staggered-grid/CMakeLists.txt
+++ b/libNeonDomain/tests/domain-unit-test-staggered-grid/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(domain-unit-test-staggered-grid PROPERTIES
 		CUDA_SEPARABLE_COMPILATION ON
 		CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(domain-unit-test-staggered-grid PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(domain-unit-test-staggered-grid PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE . PREFIX "gUt_containers" FILES ${SrcFiles})
 
 add_test(NAME domain-unit-test-staggered-grid COMMAND domain-unit-test-staggered-grid)

--- a/libNeonDomain/tests/domainUt_sGrid/CMakeLists.txt
+++ b/libNeonDomain/tests/domainUt_sGrid/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(domainUt_sGrid PROPERTIES
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(domainUt_sGrid PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(domainUt_sGrid PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "gUt_containers" FILES ${SrcFiles})
 
 add_test(NAME domainUt_sGrid COMMAND domainUt_sGrid)

--- a/libNeonDomain/tests/domainUt_swap/CMakeLists.txt
+++ b/libNeonDomain/tests/domainUt_swap/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(domainUt_swap PROPERTIES
 		CUDA_SEPARABLE_COMPILATION ON
 		CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(domainUt_swap PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(domainUt_swap PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "gUt_containers" FILES ${SrcFiles})
 
 add_test(NAME domainUt_swap COMMAND domainUt_swap)

--- a/libNeonDomain/tests/gUt_dataView_patterns/CMakeLists.txt
+++ b/libNeonDomain/tests/gUt_dataView_patterns/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(gUt_dataView_patterns
 	PUBLIC libNeonDomain
 	PUBLIC gtest_main)
 
-set_target_properties(gUt_dataView_patterns PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(gUt_dataView_patterns PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE . PREFIX "gUt_dataView_patterns" FILES ${SrcFiles})
 
 add_test(NAME gUt_dataView_patterns COMMAND gUt_dataView_patterns)

--- a/libNeonDomain/tests/gUt_mGrid/CMakeLists.txt
+++ b/libNeonDomain/tests/gUt_mGrid/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(gUt_mGrid
 	PUBLIC libNeonDomain
 	PUBLIC gtest_main)
 
-set_target_properties(gUt_mGrid PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(gUt_mGrid PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "gUt_mGrid" FILES ${SrcFiles})
 
 add_test(NAME gUt_mGrid COMMAND gUt_mGrid)

--- a/libNeonDomain/tests/gUt_periodic/_CMakeLists.txt
+++ b/libNeonDomain/tests/gUt_periodic/_CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(gUt_periodic
 	PUBLIC libNeonDomain
 	PUBLIC gtest_main)
 
-set_target_properties(gUt_periodic PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(gUt_periodic PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "gUt_periodic" FILES ${SrcFiles})
 
 add_test(NAME gUt_periodic COMMAND gUt_periodic)

--- a/libNeonDomain/tests/gUt_tools/CMakeLists.txt
+++ b/libNeonDomain/tests/gUt_tools/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(gUt_tools
 	PUBLIC libNeonDomain
 	PUBLIC gtest_main)
 
-set_target_properties(gUt_tools PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(gUt_tools PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "gUt_tools" FILES ${SrcFiles})
 
 add_test(NAME gUt_tools COMMAND gUt_tools)

--- a/libNeonDomain/tests/gUt_vtk/CMakeLists.txt
+++ b/libNeonDomain/tests/gUt_vtk/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(gUt_vtk
 	PUBLIC libNeonDomain
 	PUBLIC gtest_main)
 
-set_target_properties(gUt_vtk PROPERTIES FOLDER "libNeonDomain")
+set_target_properties(gUt_vtk PROPERTIES FOLDER "libNeonDomainTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "gUt_vtk" FILES ${SrcFiles})
 
 add_test(NAME gUt_vtk COMMAND gUt_vtk)

--- a/libNeonSet/tests/unit/setUt_Replica/CMakeLists.txt
+++ b/libNeonSet/tests/unit/setUt_Replica/CMakeLists.txt
@@ -12,7 +12,7 @@ set_target_properties(setUt_multiDeviceObject PROPERTIES
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(setUt_multiDeviceObject PROPERTIES FOLDER "libNeonSet")
+set_target_properties(setUt_multiDeviceObject PROPERTIES FOLDER "libNeonSetTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "setUt_multiDeviceObject" FILES ${SrcFiles})
 
 

--- a/libNeonSet/tests/unit/setUt_containerGraph/CMakeLists.txt
+++ b/libNeonSet/tests/unit/setUt_containerGraph/CMakeLists.txt
@@ -19,7 +19,7 @@ set_target_properties(${APP} PROPERTIES
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(${APP} PROPERTIES FOLDER "libNeonSet")
+set_target_properties(${APP} PROPERTIES FOLDER "libNeonSetTests")
 
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "${APP}" FILES ${SrcFiles})
 

--- a/libNeonSet/tests/unit/setUt_gpuSet/CMakeLists.txt
+++ b/libNeonSet/tests/unit/setUt_gpuSet/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(setUt_gpuSet
 	PUBLIC libNeonSet
 	PUBLIC gtest_main)
 
-set_target_properties(setUt_gpuSet PROPERTIES FOLDER "libNeonSet")
+set_target_properties(setUt_gpuSet PROPERTIES FOLDER "libNeonSetTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "setUt_gpuSet" FILES ${SrcFiles})
 
 add_test(NAME setUt_gpuSet COMMAND setUt_gpuSet)

--- a/libNeonSet/tests/unit/setUt_gpuSetNvcc/CMakeLists.txt
+++ b/libNeonSet/tests/unit/setUt_gpuSetNvcc/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(setUt_gpuSetNvcc
 set_target_properties(setUt_gpuSetNvcc PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(setUt_gpuSetNvcc PROPERTIES FOLDER "libNeonSet")
+set_target_properties(setUt_gpuSetNvcc PROPERTIES FOLDER "libNeonSetTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "setUt_gpuSetNvcc" FILES ${SrcFiles})
 
 add_test(NAME setUt_gpuSetNvcc COMMAND setUt_gpuSetNvcc)

--- a/libNeonSet/tests/unit/setUt_memMirrorSet/CMakeLists.txt
+++ b/libNeonSet/tests/unit/setUt_memMirrorSet/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(setUt_memMirrorSet
 	PUBLIC libNeonSet
 	PUBLIC gtest_main)
 
-set_target_properties(setUt_memMirrorSet PROPERTIES FOLDER "libNeonSet")
+set_target_properties(setUt_memMirrorSet PROPERTIES FOLDER "libNeonSetTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "setUt_memMirrorSet" FILES ${SrcFiles})
 
 add_test(NAME setUt_memMirrorSet COMMAND setUt_memMirrorSet)

--- a/libNeonSet/tests/unit/setUt_patterns/CMakeLists.txt
+++ b/libNeonSet/tests/unit/setUt_patterns/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(setUt_patterns
 	PUBLIC libNeonSet
 	PUBLIC gtest_main)
 
-set_target_properties(setUt_patterns PROPERTIES FOLDER "libNeonSet")
+set_target_properties(setUt_patterns PROPERTIES FOLDER "libNeonSetTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "setUt_patterns" FILES ${SrcFiles})
 
 

--- a/libNeonSkeleton/tests/perf/SkeletonSyntheticBenchmarks/CMakeLists.txt
+++ b/libNeonSkeleton/tests/perf/SkeletonSyntheticBenchmarks/CMakeLists.txt
@@ -11,5 +11,5 @@ set_target_properties(skeletonSyntheticBenchmarks PROPERTIES
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(skeletonSyntheticBenchmarks PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(skeletonSyntheticBenchmarks PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "skeletonSyntheticBenchmarks" FILES ${SrcFiles})

--- a/libNeonSkeleton/tests/perf/sPt_AXPY_Laplacian/CMakeLists.txt
+++ b/libNeonSkeleton/tests/perf/sPt_AXPY_Laplacian/CMakeLists.txt
@@ -11,5 +11,5 @@ target_link_libraries(sPt_AXPY_Laplacian
 set_target_properties(sPt_AXPY_Laplacian PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(sPt_AXPY_Laplacian PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(sPt_AXPY_Laplacian PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sPt_AXPY_Laplacian" FILES ${SrcFiles})

--- a/libNeonSkeleton/tests/unit/sUt_multiRes/CMakeLists.txt
+++ b/libNeonSkeleton/tests/unit/sUt_multiRes/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(sUt_multiRes
 set_target_properties(sUt_multiRes PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(sUt_multiRes PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(sUt_multiRes PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sUt_multiRes" FILES ${SrcFiles})
 
 add_test(NAME sUt_multiRes COMMAND sUt_multiRes)

--- a/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/CMakeLists.txt
+++ b/libNeonSkeleton/tests/unit/sUt_skeletonOnStreams/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(sUt_skeletonOnStreams
 set_target_properties(sUt_skeletonOnStreams PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(sUt_skeletonOnStreams PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(sUt_skeletonOnStreams PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sUt_skeletonOnStreams" FILES ${SrcFiles})
 
 add_test(NAME sUt_skeletonOnStreams COMMAND sUt_skeletonOnStreams)

--- a/libNeonSkeleton/tests/unit/sUt_userInterface/CMakeLists.txt
+++ b/libNeonSkeleton/tests/unit/sUt_userInterface/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(sUt_userInterface
 set_target_properties(sUt_userInterface PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(sUt_userInterface PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(sUt_userInterface PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sUt_userInterface" FILES ${SrcFiles})
 
 add_test(NAME sUt_userInterface COMMAND sUt_userInterface)

--- a/libNeonSkeleton/tests/unit/skeleton-maps/CMakeLists.txt
+++ b/libNeonSkeleton/tests/unit/skeleton-maps/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(skeleton-map
 set_target_properties(skeleton-map PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(skeleton-map PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(skeleton-map PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "skeleton-map" FILES ${SrcFiles})
 
 add_test(NAME skeleton-map COMMAND skeleton-map)

--- a/libNeonSkeleton/tests/unit/skeleton-stencil/CMakeLists.txt
+++ b/libNeonSkeleton/tests/unit/skeleton-stencil/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(skeleton-stencil
 set_target_properties(skeleton-stencil PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(skeleton-stencil PROPERTIES FOLDER "libNeonSkeleton")
+set_target_properties(skeleton-stencil PROPERTIES FOLDER "libNeonSkeletonTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "skeleton-stencil" FILES ${SrcFiles})
 
 add_test(NAME skeleton-stencil COMMAND skeleton-stencil)

--- a/libNeonSolver/tests/perf/solverPt_Poisson/CMakeLists.txt
+++ b/libNeonSolver/tests/perf/solverPt_Poisson/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(solverPt_Poisson
 set_target_properties(solverPt_Poisson PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(solverPt_Poisson PROPERTIES FOLDER "libNeonSolver")
+set_target_properties(solverPt_Poisson PROPERTIES FOLDER "libNeonSolverTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "solverPt_Poisson" FILES ${SrcFiles})
 
 add_test(NAME solverPt_Poisson COMMAND solverPt_Poisson)

--- a/libNeonSolver/tests/poisson/CMakeLists.txt
+++ b/libNeonSolver/tests/poisson/CMakeLists.txt
@@ -11,5 +11,5 @@ target_include_directories(poisson PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include/"
 set_target_properties(poisson PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(poisson PROPERTIES FOLDER "libNeonSolver")
+set_target_properties(poisson PROPERTIES FOLDER "libNeonSolverTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "poisson" FILES ${SrcFiles})

--- a/libNeonSolver/tests/unit/solverUt_Poisson/CMakeLists.txt
+++ b/libNeonSolver/tests/unit/solverUt_Poisson/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(solverUt_Poisson
 set_target_properties(solverUt_Poisson PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(solverUt_Poisson PROPERTIES FOLDER "libNeonSolver")
+set_target_properties(solverUt_Poisson PROPERTIES FOLDER "libNeonSolverTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "solverUt_Poisson" FILES ${SrcFiles})
 
 add_test(NAME solverUt_Poisson COMMAND solverUt_Poisson)

--- a/libNeonSys/tests/unit/sysUt_devCpu/CMakeLists.txt
+++ b/libNeonSys/tests/unit/sysUt_devCpu/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(sysUt_devCpu
 	PUBLIC libNeonSys
 	PUBLIC gtest_main)
 
-set_target_properties(sysUt_devCpu PROPERTIES FOLDER "libNeonSys")
+set_target_properties(sysUt_devCpu PROPERTIES FOLDER "libNeonSysTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sysUt_devCpu" FILES ${SrcFiles})
 
 add_test(NAME sysUt_devCpu COMMAND sysUt_devCpu)

--- a/libNeonSys/tests/unit/sysUt_devGpu/CMakeLists.txt
+++ b/libNeonSys/tests/unit/sysUt_devGpu/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(sysUt_devGpu
 	PUBLIC libNeonSys
 	PUBLIC gtest_main)
 
-set_target_properties(sysUt_devGpu PROPERTIES FOLDER "libNeonSys")
+set_target_properties(sysUt_devGpu PROPERTIES FOLDER "libNeonSysTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sysUt_devGpu" FILES ${SrcFiles})
 
 add_test(NAME sysUt_devGpu COMMAND sysUt_devGpu)

--- a/libNeonSys/tests/unit/sysUt_devGpuNvcc/CMakeLists.txt
+++ b/libNeonSys/tests/unit/sysUt_devGpuNvcc/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(sysUt_devGpuNvcc
 set_target_properties(sysUt_devGpuNvcc PROPERTIES 
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-set_target_properties(sysUt_devGpuNvcc PROPERTIES FOLDER "libNeonSys")
+set_target_properties(sysUt_devGpuNvcc PROPERTIES FOLDER "libNeonSysTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sysUt_devGpuNvcc" FILES ${SrcFiles})
 
 add_test(NAME sysUt_devGpuNvcc COMMAND sysUt_devGpuNvcc)

--- a/libNeonSys/tests/unit/sysUt_mem/CMakeLists.txt
+++ b/libNeonSys/tests/unit/sysUt_mem/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(sysUt_mem
 	PUBLIC libNeonSys
 	PUBLIC gtest_main)
 
-set_target_properties(sysUt_mem PROPERTIES FOLDER "libNeonSys")
+set_target_properties(sysUt_mem PROPERTIES FOLDER "libNeonSysTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sysUt_mem" FILES ${SrcFiles})
 
 add_test(NAME sysUt_mem COMMAND sysUt_mem)

--- a/libNeonSys/tests/unit/sysUt_patterns/CMakeLists.txt
+++ b/libNeonSys/tests/unit/sysUt_patterns/CMakeLists.txt
@@ -12,7 +12,7 @@ set_target_properties(sysUt_patterns PROPERTIES
 	CUDA_SEPARABLE_COMPILATION ON
 	CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-set_target_properties(sysUt_patterns PROPERTIES FOLDER "libNeonSys")
+set_target_properties(sysUt_patterns PROPERTIES FOLDER "libNeonSysTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sysUt_patterns" FILES ${SrcFiles})
 
 add_test(NAME sysUt_patterns COMMAND sysUt_patterns)

--- a/libNeonSys/tests/unit/sysUt_report/CMakeLists.txt
+++ b/libNeonSys/tests/unit/sysUt_report/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(sysUt_report
 	PUBLIC libNeonSys
 	PUBLIC gtest_main)
 
-set_target_properties(sysUt_report PROPERTIES FOLDER "libNeonSys")
+set_target_properties(sysUt_report PROPERTIES FOLDER "libNeonSysTests")
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR} PREFIX "sysUt_report" FILES ${SrcFiles})
 
 add_test(NAME sysUt_report COMMAND sysUt_report)


### PR DESCRIPTION
VS2022 has a problem with opening a project that has sections that have the same name. Previously, we had a `libNeonXX` name for both the `XX` library and `XX` library tests. This PR renames the test section in VS to `libNeonXXTests`